### PR TITLE
Change from sqlite3 to postgresql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,26 +31,21 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.5'
 # Jquery gem
 gem 'jquery-rails', '4.1.1'
-# Use Redis adapter to run Action Cable in production
-# gem 'redis', '~> 3.0'
-# Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+# Use postgres for test and development
+gem 'pg', '0.18.4'
 
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
 group :test do
   gem 'minitest-reporters'
   gem 'rails-controller-testing'
   gem 'factory_girl_rails'
 end
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   # Adds support for Capybara system testing and selenium driver
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
-  # Use sqlite3 as the database for Active Record
-  gem 'sqlite3'
 end
 
 group :development do
@@ -63,7 +58,6 @@ group :development do
 end
 
 group :production do
-  gem 'pg', '0.18.4'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -236,7 +235,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,24 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: 
+  password:
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: grocerist_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: grocerist_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: grocerist_production

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,10 +12,13 @@
 
 ActiveRecord::Schema.define(version: 20170604015822) do
 
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
   create_table "items", force: :cascade do |t|
     t.string "name"
     t.text "notes"
-    t.integer "list_id"
+    t.bigint "list_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at", "id"], name: "index_items_on_created_at_and_id"
@@ -24,7 +27,7 @@ ActiveRecord::Schema.define(version: 20170604015822) do
 
   create_table "lists", force: :cascade do |t|
     t.string "name"
-    t.integer "user_id"
+    t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["created_at", "id"], name: "index_lists_on_created_at_and_id"
@@ -49,4 +52,6 @@ ActiveRecord::Schema.define(version: 20170604015822) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "items", "lists"
+  add_foreign_key "lists", "users"
 end


### PR DESCRIPTION
This is a change to improve consistency between environments.  The
switch was very easy and now the sqlite3 databases are gone.  Closes #9