### PR TITLE
Re-insert flash messages for deleted items

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,19 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  
+
   before_action :configure_permitted_parameters, if: :devise_controller?
- 
+
+  after_action :clear_xhr_flash
+
   protected
-  
+
+  def clear_xhr_flash
+    if request.xhr?
+      # Also modify 'flash' to other attributes which you use in your common/flashes for js
+      flash.discard
+    end
+  end
+
   def configure_permitted_parameters
     added_attrs = [:username, :email, :password, :password_confirmation, :remember_me]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,7 @@ class ItemsController < ApplicationController
   
   def destroy
     @item.destroy
-    # flash[:success] = "#{@item.name} deleted from #{@item.list.name}"
+    flash[:success] = "#{@item.name} deleted from #{@item.list.name}"
     respond_to do |format|
       format.html { redirect_to root_url }
       format.json { head :no_content }

--- a/app/views/items/destroy.js.erb
+++ b/app/views/items/destroy.js.erb
@@ -1,3 +1,4 @@
 $('.btn-delete').bind('ajax:success', function() {  
-  $(this).closest('.list-item').fadeOut();
+  $(this).closest('.list-item').fadeOut('slow');
+  $('#flash-messages').html("<%= j render(:partial => 'layouts/alert') %>");
 });  


### PR DESCRIPTION
Flash messages for deleted items were previously removed because the
flash messages would persist after going to another page such as Help.
The new code in ApplicationController discards the flash contents for
the types of requests where we don't want to see them.  Closes #20