### PR TITLE
Fix delete button appearing in an empty list

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,8 +4,8 @@ class PagesController < ApplicationController
     if user_signed_in?
       @list = current_user.active_list
       unless @list.nil?
-        # Existing items
-        @list_items = @list.items.paginate(page: params[:page], per_page: 30) unless @list.nil?
+        # Existing items, don't create the variable if there aren't any items
+        @list_items = @list.items.paginate(page: params[:page], per_page: 30) unless @list.items.empty?
         # New item
         @item = @list.items.build
       end 


### PR DESCRIPTION
Fixed by not assigning @list_items if the items collection on the list
is empty.

What will happen when we inevitably want to add items to the list with
Ajax is uncertain.  Since adding the first item to the list will need to
render the delete button.  I think a decent way to do that will be to
make the delete button its' own partial and add it to the DOM using
jQuery, and render it from the server normally if there are already
items.